### PR TITLE
Correction: Node.js doesn’t support `btoa()`

### DIFF
--- a/_posts/2012-08-10-non-alphanumeric-javascript.md
+++ b/_posts/2012-08-10-non-alphanumeric-javascript.md
@@ -211,7 +211,7 @@ room from improvments:
 
 * Once we were able to generate all ASCII characters, no effort was made to get
     the shortest representation of any of them.
-* When targeting modern browsers only or node.js, `btoa` would be a great help
+* When targeting modern browsers only, `btoa` would be a great help
     yielding lots of characters in shorter sequences.
 * Depending on the target, one may select a bigger alphabet for reducing the
     encoding size.


### PR DESCRIPTION
Only browsers have to implement it, as it’s part of the HTML spec, not ECMAScript: http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#atob.

Instead, you can use `new Buffer('Hello World').toString('base64')` — which is different than `btoa` in that it encodes the string as UTF-8 first, while `btoa` only accepts extended ASCII characters. For example, `btoa('foo ♥ bar')` throws an error, but `new Buffer('foo ♥ bar').toString('base64')` works just fine. See http://mothereff.in/base64 for some more info and https://github.com/mathiasbynens/mothereff.in/blob/master/base64/eff.js for example code.
